### PR TITLE
#157110840 cache nutritional values

### DIFF
--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -738,6 +738,10 @@ class MealItem(models.Model):
 @receiver(post_delete, sender=MealItem)
 
 def handle_cache(sender, **kwargs):
+    '''
+    deletes the cached data nutrition database is changed
+    '''
+
     model = kwargs.get('instance')
     if isinstance(model, (Meal, MealItem)):
         cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -33,6 +33,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -117,50 +119,55 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        nutrition_values = cache.get(cache_mapper.get_nutrition_item(self.id))
+        if not nutrition_values:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                    'percent': {'protein': 0,
+                                'carbohydrates': 0,
+                                'fat': 0},
+                    'per_kg': {'protein': 0,
+                                'carbohydrates': 0,
+                                'fat': 0},
+                    }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * \
-                    ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * \
+                        ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = \
-                    result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = \
+                        result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+
+            cache.set(cache_mapper.get_nutrition_item(self.id), result)
+            cache.close()
 
         return result
 
@@ -722,3 +729,18 @@ class MealItem(models.Model):
                 Decimal(nutritional_info[i]).quantize(TWOPLACES)
 
         return nutritional_info
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=MealItem)
+
+def handle_cache(sender, **kwargs):
+    model = kwargs.get('instance')
+    if isinstance(model, (Meal, MealItem)):
+        cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))
+    else:
+        cache.delete(cache_mapper.get_nutrition_item(model.id))
+

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -123,21 +123,28 @@ class NutritionPlan(models.Model):
         if not result:
             use_metric = self.user.userprofile.use_metric
             unit = 'kg' if use_metric else 'lb'
-            result = {'total': {'energy': 0,
-                                'protein': 0,
-                                'carbohydrates': 0,
-                                'carbohydrates_sugar': 0,
-                                'fat': 0,
-                                'fat_saturated': 0,
-                                'fibres': 0,
-                                'sodium': 0},
-                    'percent': {'protein': 0,
-                                'carbohydrates': 0,
-                                'fat': 0},
-                    'per_kg': {'protein': 0,
-                                'carbohydrates': 0,
-                                'fat': 0},
-                    }
+            result = {
+                'total': {
+                    'energy': 0,
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'carbohydrates_sugar': 0,
+                    'fat': 0,
+                    'fat_saturated': 0,
+                    'fibres': 0,
+                    'sodium': 0
+                    },
+                'percent': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                    },
+                'per_kg': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                    },
+                }
 
             # Energy
             for meal in self.meal_set.select_related():
@@ -730,13 +737,13 @@ class MealItem(models.Model):
 
         return nutritional_info
 
+
 @receiver(post_save, sender=NutritionPlan)
 @receiver(post_delete, sender=NutritionPlan)
 @receiver(post_save, sender=Meal)
 @receiver(post_delete, sender=Meal)
 @receiver(post_save, sender=MealItem)
 @receiver(post_delete, sender=MealItem)
-
 def handle_cache(sender, **kwargs):
     '''
     deletes the cached data nutrition database is changed
@@ -747,4 +754,3 @@ def handle_cache(sender, **kwargs):
         cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))
     else:
         cache.delete(cache_mapper.get_nutrition_item(model.id))
-

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -119,8 +119,8 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        nutrition_values = cache.get(cache_mapper.get_nutrition_item(self.id))
-        if not nutrition_values:
+        result = cache.get(cache_mapper.get_nutrition_item(self.id))
+        if not result:
             use_metric = self.user.userprofile.use_metric
             unit = 'kg' if use_metric else 'lb'
             result = {'total': {'energy': 0,

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -122,4 +122,5 @@ class CacheKeyMapper(object):
         '''
         return self.NUTRITION_CACHE_KEY.format(self.get_pk(param))
 
+
 cache_mapper = CacheKeyMapper()

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITION_CACHE_KEY = 'nutrition-{0}'
 
     def get_pk(self, param):
         '''
@@ -115,5 +116,10 @@ class CacheKeyMapper(object):
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
 
+    def get_nutrition_item(self, param):
+        '''
+        return nutrition cache key
+        '''
+        return self.NUTRITION_CACHE_KEY.format(self.get_pk(param))
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?
caches nutritional plan and add signals that delete the cache every time its deleted

#### Description of Task to be completed?
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

#### How should this be manually tested?
run `python manage.py test wger.nutrition.tests.test_nutritional_calculations`after cloning and setting up the project

#### What are the relevant pivotal tracker stories?
[#157110840](https://www.pivotaltracker.com/story/show/157110840)

#### Screenshots

before caching
<img width="1029" alt="screen shot 2018-05-17 at 12 23 10" src="https://user-images.githubusercontent.com/19773670/40169366-88e65e66-59ce-11e8-9281-8d1d4c850e48.png">

after caching 

<img width="1039" alt="screen shot 2018-05-17 at 12 23 44" src="https://user-images.githubusercontent.com/19773670/40169421-a27848f8-59ce-11e8-831d-1527040f25cf.png">

