### PR TITLE
#157110848 Allow comparison of members

### DIFF
--- a/wger/core/templates/comparison.html
+++ b/wger/core/templates/comparison.html
@@ -1,0 +1,82 @@
+{% extends "base_wide.html" %} {% load i18n staticfiles wger_extras %} {% block title %}{% trans "Weight Comparison" %}{% endblock%}
+{% block header %}
+<script src="{% static 'js/user.js' %}"></script> 
+{% endblock %} {% block content %}
+
+<div id="current-username" data-current-username="{{ owner_user.username }}" value="{{ owner_user.username }}"></div>
+
+<div class="row">
+
+    <div class="col-md-6">
+        My Graph
+        {% if not min_date %}
+        <p>
+            {% trans "There is no chart here because there are no weight entries." %}
+        </p>
+        {% endif %}
+        <div id="user_diagram"></div>
+    </div>
+
+    <div class="col-md-6">
+        <select id="user-change" onchange="userchange(this.value)">
+            <option value="none">--------</option>
+            {% for user in others %}
+            <option value="{{user}}">{{ user }} </option>
+            {% endfor %}
+        </select>
+        <p id="nope">There is no chart here because there are no weight entries.</p>
+        <div id="others_diagram"></div>
+        
+       
+
+    </div>
+</div>
+<script>
+  function userchange(username) {
+  var url;
+  var chartParams;
+  var weightChart;
+  weightChart = {};
+  chartParams = {
+    animate_on_load: true,
+    full_width: true,
+    top: 10,
+    left: 30,
+    right: 10,
+    show_secondary_x_label: true,
+    xax_count: 10,
+    target: '#others_diagram',
+    x_accessor: 'date',
+    y_accessor: 'weight',
+    min_y_from_data: true,
+    colors: ['#3465a4']
+  };
+  url = '/weight/api/get_user_weight_data/' + username;
+  d3.json(url, function (json) {
+    var data;
+    if (json.length) {
+      $('#others_diagram').show();
+      data = MG.convert.date(json, 'date');
+      weightChart.data = data;
+      // Plot the data
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+      $('#nope').hide();
+    } else {
+      $('#nope').show();
+      $('#others_diagram').hide();
+    }
+  });
+  $('.modify-time-period-controls button').click(function () {
+    var pastNumberDays = $(this).data('time_period');
+    var data = modifyTimePeriod(weightChart.data, pastNumberDays);
+    // change button state
+    $(this).addClass('active').siblings().removeClass('active');
+    if (data.length) {
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+}
+</script>
+{% endblock %}

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -152,6 +152,19 @@
                         </li>
 
                         {#                     #}
+                        {# comparison graphs   #}
+                        {#                     #}
+                        <li {% if active_tab == 'user' %}class="active"{% endif %}>
+                            <a href="{% url 'core:comparison'%}">
+                                {% if not user.is_authenticated %}
+                                {% trans "Features" %}
+                                {% else %}
+                                {% trans "Comparison" %}
+                                {% endif %}
+                            </a>    
+                        </li>
+
+                        {#                     #}
                         {# Options and contact #}
                         {#                     #}
                         <li class="dropdown visible-xs-block visible-sm-block">

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -65,7 +65,8 @@
     <script src="{% static 'js/popper.js' %}"></script>
     <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'bower_components/Sortable/Sortable.min.js' %}"></script>
-    <script src="{% static 'bower_components/d3/d3.js' %}"></script>
+    <!-- <script src="{% static 'bower_components/d3/d3.js' %}"></script> -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.js"></script>
     <script src="{% static 'bower_components/metrics-graphics/dist/metricsgraphics.min.js' %}"></script>
     <script src="{% static 'bower_components/devbridge-autocomplete/dist/jquery.autocomplete.min.js' %}"></script>
     <script src="{% static 'js/wger-core.js' %}"></script>

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -206,6 +206,9 @@ urlpatterns = [
         misc.FeedbackClass.as_view(),
         name='feedback'),
 
+     #comparison
+    url(r'^comparison$', misc.comparison, name='comparison'),
+
     url(r'^language/', include(patterns_language, namespace="language")),
     url(r'^user/', include(patterns_user, namespace="user")),
     url(r'^license/', include(patterns_license, namespace="license")),

--- a/wger/core/views/misc.py
+++ b/wger/core/views/misc.py
@@ -30,6 +30,9 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login as django_login
 from django.template.loader import render_to_string
+from django.contrib.auth.models import User
+from django.db.models import Min
+from django.db.models import Max
 
 
 from wger.core.forms import FeedbackRegisteredForm, FeedbackAnonymousForm
@@ -40,6 +43,8 @@ from wger.nutrition.models import NutritionPlan
 from wger.weight.models import WeightEntry
 from wger.weight.helpers import get_last_entries
 from .fitbit import FitBit
+from wger.weight import helpers
+from wger.utils.helpers import check_access
 
 
 logger = logging.getLogger(__name__)
@@ -145,6 +150,45 @@ def dashboard(request):
         template_data['nutritional_info'] = plan.get_nutritional_values()
 
     return render(request, 'index.html', template_data)
+
+def comparison(request, username=None):
+    '''
+    Analysis view
+    '''
+    users = list(User.objects.all())
+
+    is_owner, user = check_access(request.user, username)
+    others = User.objects.exclude(username=user.username)
+
+    template_data = {}
+
+    min_date = WeightEntry.objects.filter(user=user).aggregate(Min('date'))['date__min']
+    max_date = WeightEntry.objects.filter(user=user).\
+        aggregate(Max('date'))['date__max']
+
+    if min_date:
+        template_data['min_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' %\
+                {'year': min_date.year,
+                 'month': min_date.month,
+                 'day': min_date.day}
+    if max_date:
+        template_data['max_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' %\
+                {'year': max_date.year,
+                 'month': max_date.month,
+                 'day': max_date.day}
+
+    last_weight_entries = helpers.get_last_entries(user)
+
+    template_data['users'] = users
+    template_data['others'] = others
+    template_data['is_owner'] = is_owner
+    template_data['owner_user'] = user
+    template_data['show_shariff'] = is_owner
+    template_data['last_five_weight_entries_details'] = last_weight_entries
+
+    if request.user.is_authenticated():
+        return render(request, 'comparison.html', template_data)
+    return render(request, 'index.html')
 
 
 class ContactClassView(TemplateView):

--- a/wger/utils/month_range.py
+++ b/wger/utils/month_range.py
@@ -1,0 +1,12 @@
+'''return the range of days for the current month'''
+from datetime import date, timedelta
+import calendar
+
+
+def get_month_range(start_date=None):
+    '''calculate the month range'''
+    if start_date is None:
+        start_date = date.today().replace(day=1)
+    month_range = calendar.monthrange(start_date.year, start_date.month)
+    end_date = start_date + timedelta(days=month_range[1]-1)
+    return (start_date, end_date)

--- a/wger/weight/static/js/user.js
+++ b/wger/weight/static/js/user.js
@@ -1,0 +1,78 @@
+/*
+ This file is part of wger Workout Manager.
+ wger Workout Manager is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ wger Workout Manager is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU Affero General Public License
+ */
+'use strict';
+
+function modifyTimePeriod(data, pastNumberDays) {
+  var filtered;
+  var date;
+  if (data.length) {
+    if (pastNumberDays !== 'all') {
+      date = new Date();
+      date.setDate(date.getDate() - pastNumberDays);
+      filtered = MG.clone(data).filter(function (value) {
+        return value.date >= date;
+      });
+      return filtered;
+    }
+  }
+  return data;
+}
+
+$(document).ready(function () {
+  var url;
+  var username;
+  var chartParams;
+  var weightChart;
+  weightChart = {};
+  chartParams = {
+    animate_on_load: true,
+    full_width: true,
+    top: 10,
+    left: 30,
+    right: 10,
+    show_secondary_x_label: true,
+    xax_count: 10,
+    target: '#user_diagram',
+    x_accessor: 'date',
+    y_accessor: 'weight',
+    min_y_from_data: true,
+    colors: ['#3465a4']
+  };
+
+  username = $('#current-username').data('currentUsername');
+  url = '/weight/api/get_logged_user_weight_data/' + username;
+
+  d3.json(url, function (json) {
+    var data;
+    if (json.length) {
+      data = MG.convert.date(json, 'date');
+      weightChart.data = data;
+
+      // Plot the data
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+
+  $('.modify-time-period-controls button').click(function () {
+    var pastNumberDays = $(this).data('time_period');
+    var data = modifyTimePeriod(weightChart.data, pastNumberDays);
+
+    // change button state
+    $(this).addClass('active').siblings().removeClass('active');
+    if (data.length) {
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+});

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -50,4 +50,12 @@ urlpatterns = [
     url(r'^api/get_weight_data/$',  # JS
         views.get_weight_data,
         name='weight-data'),
+    url(r'^api/get_logged_user_weight_data/(?P<username>[\w.@+-]+)$', # JS
+        views.get_logged_user_weight_data,
+        name='logged_user_weight-data',
+       ),
+    url(r'^api/get_user_weight_data/(?P<username>[\w.@+-]+)$', # JS
+        views.get_user_weight_data,
+        name='user_weight-data',
+       ),
 ]

--- a/wger/weight/views.py
+++ b/wger/weight/views.py
@@ -31,6 +31,8 @@ from django.db.models import Min
 from django.db.models import Max
 from django.views.generic import CreateView
 from django.views.generic import UpdateView
+from django.contrib.auth.models import User
+from wger.utils.month_range import get_month_range
 
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
@@ -188,6 +190,45 @@ def get_weight_data(request, username=None):
     for i in weights:
         chart_data.append({'date': i.date,
                            'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+@api_view(['GET'])
+def get_logged_user_weight_data(request, username=None):
+    '''
+      Process the user data and pass it to the JS libraries to generate a SVG image
+    '''
+    is_owner, user = check_access(request.user, username)
+    date_min_max = get_month_range()
+
+    if date_min_max:
+        weights = WeightEntry.objects.filter(user=user, date__range=date_min_max)
+    else:
+        weights = WeightEntry.objects.filter(user=user)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+
+@api_view(['GET'])
+def get_user_weight_data(request, username=None):
+    '''
+      Process the user data and pass it to the JS libraries to generate a SVG image
+    '''
+    user = User.objects.filter(username=username)
+    date_min_max = get_month_range()
+    weights = WeightEntry.objects.filter(user=user, date__range=date_min_max)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
 
     # Return the results to the client
     return Response(chart_data)


### PR DESCRIPTION
#### What does this PR do?
allows two users to compare their weight 
#### Description of Task to be completed?
When two users are training together it would be useful to see a comparison of some sorts. A possibility would be to have a graph where the data for (selected) members is shown.
#### How should this be manually tested?
After cloning checkout to `ft-memeber-comparison` then navigate to the weight and add new weight. add several weigh. Navigate to the comparison tab there you will see a graph. if there was another user you can select the user and compare their graph also.
#### What are the relevant pivotal tracker stories?
[157110848](https://www.pivotaltracker.com/story/show/157110848)

#### Screenshots
<img width="1277" alt="screen shot 2018-05-30 at 21 51 13" src="https://user-images.githubusercontent.com/19773670/40741305-ed551d12-6453-11e8-8a71-e92c83997b00.png">

<img width="1280" alt="screen shot 2018-05-30 at 21 51 57" src="https://user-images.githubusercontent.com/19773670/40741320-f89441a8-6453-11e8-9fc3-1cae6a10cf15.png">


